### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ wrap(str, {indent: '      '});
 
 Type: `String`
 
-Default: `"`
+Default: `\n`
 
 The string to use at the end of each line.
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ Wrap words to a specified length.
 ## Usage
 
 ```js
-import wrap from 'https://deno.land/x/word_wrap/mod.ts';
+import wrap from "https://deno.land/x/word_wrap/mod.ts";
 
-wrap('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.');
+wrap(
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+);
 ```
 
 Results in:
@@ -47,7 +49,7 @@ The width of the text before wrapping to a new line.
 **Example:**
 
 ```ts
-wrap(str, {width: 60});
+wrap(str, { width: 60 });
 ```
 
 ### options.indent
@@ -61,7 +63,7 @@ The string to use at the beginning of each line.
 **Example:**
 
 ```ts
-wrap(str, {indent: '      '});
+wrap(str, { indent: "      " });
 ```
 
 ### options.newline
@@ -75,7 +77,7 @@ The string to use at the end of each line.
 **Example:**
 
 ```ts
-wrap(str, {newline: '\n\n'});
+wrap(str, { newline: "\n\n" });
 ```
 
 ### options.escape
@@ -90,9 +92,9 @@ An escape function to run on each line after splitting them.
 
 ```ts
 wrap(str, {
-  escape: function(str: string): string {
+  escape: function (str: string): string {
     return str.toUpperCase();
-  }
+  },
 });
 ```
 
@@ -102,12 +104,13 @@ Type: `Boolean`
 
 Default: `false`
 
-Trim trailing whitespace from the returned string. This option is included since `.trim()` would also strip the leading indentation from the first line.
+Trim trailing whitespace from the returned string. This option is included since
+`.trim()` would also strip the leading indentation from the first line.
 
 **Example:**
 
 ```ts
-wrap(str, {trim: true});
+wrap(str, { trim: true });
 ```
 
 ### options.cut
@@ -116,14 +119,16 @@ Type: `Boolean`
 
 Default: `false`
 
-Break a word between any two letters when the word is longer than the specified width.
+Break a word between any two letters when the word is longer than the specified
+width.
 
 **Example:**
 
 ```ts
-wrap(str, {cut: true});
+wrap(str, { cut: true });
 ```
 
 ## License
 
-[deno_word_wrap](https://github.com/justjavac/deno_word_wrap) is released under the MIT License. See the bundled [LICENSE](./LICENSE) file for details.
+[deno_word_wrap](https://github.com/justjavac/deno_word_wrap) is released under
+the MIT License. See the bundled [LICENSE](./LICENSE) file for details.

--- a/mod.ts
+++ b/mod.ts
@@ -8,28 +8,28 @@
 export interface IOptions {
   /**
    * The width of the text before wrapping to a new line.
-   * 
+   *
    * default `50`
    */
   width?: number;
 
   /**
    * The string to use at the beginning of each line.
-   * 
+   *
    * default `""` (none)
    */
   indent?: string;
 
   /**
    * The string to use at the end of each line.
-   * 
+   *
    * default `"\n"`
    */
   newline?: string;
 
   /**
    * An escape function to run on each line after splitting them.
-   * 
+   *
    * default `(str: string) => string`
    */
   escape?: (str: string) => string;
@@ -38,7 +38,7 @@ export interface IOptions {
    * Trim trailing whitespace from the returned string.
    * This option is included since `.trim()` would also strip
    * the leading indentation from the first line.
-   * 
+   *
    * default `true`
    */
   trim?: boolean;
@@ -54,7 +54,7 @@ export interface IOptions {
 /**
  * Wrap words to a specified length.
  * @param str
- * @param options 
+ * @param options
  */
 export default function wrap(str: string, options?: IOptions): string {
   options = options || {};

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,5 +1,5 @@
 // see https://github.com/jonschlinkert/word-wrap/blob/0a0e06bfe215f3bf3f15f084b3640ed354770a19/test.js
-import { assertEquals } from "https://deno.land/std@0.68.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.103.0/testing/asserts.ts";
 
 import wrap from "./mod.ts";
 


### PR DESCRIPTION
Change options.newline's default from `"` to `\n` in README